### PR TITLE
Broken links

### DIFF
--- a/docs/pickit/intro.md
+++ b/docs/pickit/intro.md
@@ -12,7 +12,7 @@ sidebar_position: 1
 
 ---
 
-### [Custom pickits](custom/#custom-pickits)
+### [Custom pickits](custom-pickits)
 
 Some pickit files were shared in the past on blizzhackers.cc and projectetal.com by many users, and some were added from [autosmurf](https://github.com/blizzhackers/autosmurf/tree/master/d2bs/kolbot/pickit/autosmurf) and sonic [repo1](https://github.com/SetupSonic/clean-sonic/tree/master/pickit) + [repo2](https://github.com/SetupSonic/d2bot-with-kolbot-sonic/tree/master/d2bs/kolbot/pickit/Sonic) :
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,8 +25,8 @@ const config = {
   deploymentBranch: "gh-pages",
   trailingSlash: false,
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
Set to throw instead of warning on broken links so they are easily detected during deployment.

Fix broken link to custom pickits inside pickit intro